### PR TITLE
hash, database: refactor database logic to use specialized hashSets (…

### DIFF
--- a/safebrowser_system_test.go
+++ b/safebrowser_system_test.go
@@ -181,13 +181,12 @@ func TestSafeBrowser(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(sb.db.tbd) == 0 {
-		t.Errorf("threatsByDescriptor is empty")
-	}
-	if len(sb.db.tbh) == 0 {
-		t.Errorf("threatsByHash is empty")
+	for _, hs := range sb.db.tfl {
+		if hs.Len() == 0 {
+			t.Errorf("Database length: got %d,, want >0", hs.Len())
+		}
 	}
 	if len(sb.c.pttls) != 1 {
-		t.Errorf("Cache length: want = 1, got = %d", len(sb.c.pttls))
+		t.Errorf("Cache length: got %d, want 1", len(sb.c.pttls))
 	}
 }


### PR DESCRIPTION
…#19)

Create a custom datastructure hashSet that is optimized for storing
sets of hashes that are most likely to be 4 bytes in length.
Use this data structure instead of naive maps to reduce memory
inefficiencies resulting from storing string structs to memories on
the heap.

Furthermore, flip the dimensionality of the database lookup structure.
Rather than being a map (keyed by hashes) to slices of ThreatDescriptors,
make it so that it is a map (keyed by ThreatDescriptors) to hashSets.
This is more efficient since that are only expected to be a small handful
of ThreatDescriptors, while we can reasonably assume that there will
be millions of hashes.

Lastly, for the database update structure, avoid storing a full list
of all the hashes. We can already regenerate these from the hashSets
when it comes time to actually update (which is very rare from the
perspective of a CPU and memory system). Thus, there is no point
holding on to memory that can be regenerated from the hashSet.